### PR TITLE
porcentagem de conclusao de video e curso

### DIFF
--- a/src/components/curso/cursoContent.module.scss
+++ b/src/components/curso/cursoContent.module.scss
@@ -21,6 +21,7 @@
       justify-content: center;
       background-color: black;
 
+      div,
       iframe {
         border: none;
         width: 100%;

--- a/src/components/vimeoPlayer/VimeoPlayer.tsx
+++ b/src/components/vimeoPlayer/VimeoPlayer.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useRef, useState } from "react";
+import Player from "@vimeo/player";
+
+function VimeoPlayer({
+  videoId,
+  onWatchedPercentageChange,
+  watchedPercentage,
+}) {
+  const playerRef = useRef(null);
+
+  useEffect(() => {
+    const player = new Player(playerRef.current, { id: videoId });
+
+    player.ready().then(() => {
+      player.getDuration().then((duration) => {
+        player.setCurrentTime(watchedPercentage * duration);
+      });
+
+      player.on("play", function () {
+        console.log("played the video!");
+      });
+
+      player.on("timeupdate", function (data) {
+        player
+          .getDuration()
+          .then((duration) => {
+            const newWatchedPercentage = (
+              (data.seconds / duration) *
+              100
+            ).toFixed(2);
+            onWatchedPercentageChange(newWatchedPercentage);
+            console.log(`Watched ${newWatchedPercentage}% of the video`);
+          })
+          .catch((err) => {
+            console.error("Error getting video duration:", err);
+          });
+      });
+    });
+
+    return () => {
+      player.destroy();
+    };
+  }, [videoId]);
+
+  return (
+    <div>
+      <div ref={playerRef} />
+    </div>
+  );
+}
+
+export default VimeoPlayer;

--- a/src/pages/course/[course_id]/[lesson_order].tsx
+++ b/src/pages/course/[course_id]/[lesson_order].tsx
@@ -56,7 +56,7 @@ function getSelectedLesson(lessons, order) {
   const activeLesson = lessons.filter(
     (element) => element.order.toString() === order
   );
-  return activeLesson[0];
+  return activeLesson[0] || null;
 }
 
 export const getServerSideProps = withSSRAuth(async (ctx) => {


### PR DESCRIPTION
Boa tarde camaradas,
Fiz pra mostrar embaixo do vídeo a porcentagem de conclusão do vídeo e do curso.
Como está salvo em state, quando recarrega a página se perde esse progresso, não sabia qual a forma que vocês preferem de persistir isso.
e a conclusão do curso está sendo calculada com base na porcentagem de conclusão de cada vídeo, seria melhor ser calculado com base na duração, mas não descobri uma forma de pegar essa duração sem antes carregar o vídeo, teria que pegar ou na API do vimeo, ou no back (na interface Lesson teria que ter uma propriedade duration).
Além disso, está recuperando o tempo em que o usuário parou, então quando ele clica em outro vídeo e retorna, continua de onde parou.